### PR TITLE
feat(v1): deploy EtomicSwap to Gnosis and GLEEC mainnets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,8 @@ EWC_RPC_URL=
 SMARTBCH_RPC_URL=
 UBIQ_RPC_URL=
 QTUM_RPC_URL=
+GNOSIS_RPC_URL=https://rpc.gnosischain.com
+GLEEC_RPC_URL=https://evm-rpc.gleec.com
 
 # ============ BLOCK EXPLORER API KEYS ============
 ETHERSCAN_API_KEY=

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -14,9 +14,10 @@ Same address on every EVM chain via deterministic CREATE2 deployment.
 |-------|----------|---------|----------|
 | Ethereum | 1 | `0xd78d0b7138fb1657da3d61e4db664d08b85fbcbb92ebf457cc8e3fa1f4d45a5c` | [etherscan.io](https://etherscan.io/address/0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1#code) |
 | Sepolia (testnet) | 11155111 | `0x0ce7879bdb6546e1a806bab1a8c09f990622bab69ae252cb79c5a04418a4150b` | [sepolia.etherscan.io](https://sepolia.etherscan.io/address/0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1#code) |
-| GLEEC testnet | 11169 | `0x7b4c6ba0a553ed83f5f2c9149ed03bdb1e1de28577a358ffd883f741db472307` | [explorer.gleec.dev](https://explorer.gleec.dev/address/0x51d9EfFc20F6965bc8DFD37E797ac52a72fcdb9D) |
+| Gnosis | 100 | `0x314c35376fe1a1a60280e3d277efb595aca4e2a205d390077caa54e9859cce65` | [gnosisscan.io](https://gnosisscan.io/address/0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1#code) |
+| GLEEC | 11169 | `0x6754c145246aad97a3295e11005497e29dc35740c98e1a63144491e08bbd1b60` | [evm-explorer.gleec.com](https://evm-explorer.gleec.com/address/0x51d9EfFc20F6965bc8DFD37E797ac52a72fcdb9D) |
 
-> **Note:** GLEEC testnet uses a non-CREATE2 deployment (address `0x51d9EfFc20F6965bc8DFD37E797ac52a72fcdb9D`) because CreateX is not available on this chain.
+> **Note:** GLEEC uses a non-CREATE2 deployment at `0x51d9EfFc20F6965bc8DFD37E797ac52a72fcdb9D` because CreateX is not available on this chain. The address is `CREATE(deployer, nonce=0)`.
 
 ## Deployment Steps
 
@@ -51,7 +52,7 @@ Where `<network-name>` matches a key in `hardhat.config.js` `networks` (e.g., `b
 npx hardhat verify --network <network-name> 0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1
 ```
 
-For chains using Etherscan V2, the single `ETHERSCAN_API_KEY` works. For chains with custom explorers (KCC, EWC), see `customChains` in `hardhat.config.js`.
+For chains using Etherscan V2, the single `ETHERSCAN_API_KEY` works. For chains with custom Blockscout explorers (KCC, EWC, GLEEC), see `customChains` in `hardhat.config.js`. Note that `apiKey` must be configured as an **object** (per-network keys) rather than a string for `customChains` to take effect — `hardhat-verify` routes string-form `apiKey` through the Etherscan V2 endpoint and silently ignores `customChains`.
 
 ### Adding a new chain
 
@@ -95,3 +96,13 @@ For chains using Etherscan V2, the single `ETHERSCAN_API_KEY` works. For chains 
   - Byte 20: `0x00` (cross-chain mode — same address on all chains)
   - Bytes 21-31: mined entropy via [createXcrunch](https://github.com/pcaversaccio/createx-crunch)
 - **Previous V1 Contract** (no SafeERC20): `0x24ABE4c71FC658C91313b6552cd40cD808b3Ea80`
+
+### Reproducibility pins (do not change without redeploying)
+
+The canonical CREATE2 address depends on byte-exact creation bytecode. These compiler/dependency settings must remain pinned to reproduce `0x61EEC68C...`:
+
+- `@openzeppelin/contracts` — pinned to **exact `5.0.0`** in `package.json`. OZ 5.3.0+ ships a different `SafeERC20.sol` that produces different EtomicSwap bytecode.
+- `solidity.settings.evmVersion` — pinned to `"paris"` in `hardhat.config.js`. solc 0.8.33 defaults to a newer EVM target (PUSH0 etc.) that produces different bytecode.
+- `solidity.settings.optimizer.runs` — `10000`.
+
+If any of these change, every future CREATE2 deploy will land at a new address and break the "same address everywhere" invariant.

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -12,11 +12,19 @@ if (!ETOMIC_SWAP_V1_CREATE2_SALT) {
   );
 }
 
-const networkConfig = (chainId, rpcEnvVar) => ({
+const networkConfig = (chainId, rpcEnvVar, extra = {}) => ({
   url: process.env[rpcEnvVar] || "",
   accounts: DEPLOYER_PRIVATE_KEY ? [DEPLOYER_PRIVATE_KEY] : [],
   chainId,
+  ...extra,
 });
+
+// GLEEC mainnet's RPC sits behind Cloudflare bot protection that 503s requests
+// without a browser-like User-Agent, so override the default Hardhat UA.
+const GLEEC_HTTP_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+};
 
 module.exports = {
   solidity: {
@@ -26,6 +34,10 @@ module.exports = {
         enabled: true,
         runs: 10000,
       },
+      // Pin EVM target to match the original Ethereum/Sepolia deployment bytecode.
+      // Without this, solc 0.8.33 defaults to a newer target (PUSH0 etc.) and CREATE2
+      // would produce a different address.
+      evmVersion: "paris",
     },
   },
 
@@ -55,15 +67,16 @@ module.exports = {
     polygonMumbai: networkConfig(80001, "POLYGON_MUMBAI_RPC_URL"),
     avalancheFujiTestnet: networkConfig(43113, "AVALANCHE_TESTNET_RPC_URL"),
     ftmTestnet: networkConfig(4002, "FANTOM_TESTNET_RPC_URL"),
-    gleecTestnet: networkConfig(11169, "GLEEC_TESTNET_RPC_URL"),
+    gleecTestnet: networkConfig(11169, "GLEEC_TESTNET_RPC_URL", { httpHeaders: GLEEC_HTTP_HEADERS }),
 
-    // ============ MAINNETS (17) ============
+    // ============ MAINNETS (19) ============
     mainnet: networkConfig(1, "MAINNET_RPC_URL"),
     bsc: networkConfig(56, "BSC_RPC_URL"),
     polygon: networkConfig(137, "POLYGON_RPC_URL"),
     avalanche: networkConfig(43114, "AVALANCHE_RPC_URL"),
     arbitrumOne: networkConfig(42161, "ARBITRUM_RPC_URL"),
     base: networkConfig(8453, "BASE_RPC_URL"),
+    gnosis: networkConfig(100, "GNOSIS_RPC_URL"),
     kcc: networkConfig(321, "KCC_RPC_URL"),
     moonriver: networkConfig(1285, "MOONRIVER_RPC_URL"),
     moonbeam: networkConfig(1284, "MOONBEAM_RPC_URL"),
@@ -75,12 +88,38 @@ module.exports = {
     smartbch: networkConfig(10000, "SMARTBCH_RPC_URL"),
     ubiq: networkConfig(8, "UBIQ_RPC_URL"),
     qtum: networkConfig(3888, "QTUM_RPC_URL"), // Included for deployment only (no explorer verification config yet)
+    gleec: networkConfig(11169, "GLEEC_RPC_URL", { httpHeaders: GLEEC_HTTP_HEADERS }), // Same chainId as gleecTestnet — chain migrated; testnet entry kept above for historical reference
   },
 
   etherscan: {
-    // Etherscan V2: single API key works for all V2-supported chains
-    // (Ethereum, BSC, Polygon, Arbitrum, Base, Avalanche, Optimism, etc.)
-    apiKey: process.env.ETHERSCAN_API_KEY,
+    // hardhat-verify needs per-network keys (object form) for customChains
+    // entries to take effect. If apiKey is a single string, every network
+    // is routed through the Etherscan V2 unified API and customChains is
+    // ignored — which breaks Blockscout chains like KCC/EWC/GLEEC.
+    //
+    // For chains on Etherscan V2 (mainnet, bsc, polygon, avalanche, arbitrumOne,
+    // base, gnosis, moonriver, moonbeam, opera, harmony, etc.), use the unified
+    // ETHERSCAN_API_KEY. For Blockscout chains, any non-empty string works
+    // (Blockscout does not require a key).
+    apiKey: (() => {
+      const v2 = process.env.ETHERSCAN_API_KEY;
+      const blockscout = "no-key-needed";
+      const keys = {};
+      for (const n of [
+        "mainnet", "sepolia",
+        "bsc", "bscTestnet",
+        "polygon", "polygonMumbai",
+        "avalanche", "avalancheFujiTestnet",
+        "arbitrumOne", "arbitrumSepolia",
+        "base", "baseSepolia",
+        "gnosis",
+        "moonriver", "moonbeam",
+        "opera", "ftmTestnet",
+        "harmony",
+      ]) keys[n] = v2;
+      for (const n of ["kcc", "ewc", "gleec", "gleecTestnet"]) keys[n] = blockscout;
+      return keys;
+    })(),
 
     // For chains NOT in Etherscan V2, add customChains with their own explorer
     customChains: [
@@ -106,6 +145,14 @@ module.exports = {
         urls: {
           apiURL: "https://explorer.gleec.dev/api",
           browserURL: "https://explorer.gleec.dev",
+        },
+      },
+      {
+        network: "gleec",
+        chainId: 11169,
+        urls: {
+          apiURL: "https://evm-explorer.gleec.com/api",
+          browserURL: "https://evm-explorer.gleec.com",
         },
       },
     ],

--- a/package.json
+++ b/package.json
@@ -13,19 +13,19 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@openzeppelin/contracts": "^5.4.0"
+    "@openzeppelin/contracts": "5.0.0"
   },
   "devDependencies": {
-    "hardhat": "^2.26.0",
     "@nomicfoundation/hardhat-ethers": "^3.1.0",
     "@nomicfoundation/hardhat-ignition": "^0.15.16",
     "@nomicfoundation/hardhat-ignition-ethers": "^0.15.16",
-    "@nomicfoundation/ignition-core": "^0.15.15",
     "@nomicfoundation/hardhat-verify": "^2.0.13",
-    "dotenv": "^16.4.5",
-    "ethers": "^6.14.0",
+    "@nomicfoundation/ignition-core": "^0.15.15",
     "chai": "^4.3.10",
     "chai-as-promised": "^7.1.1",
+    "dotenv": "^16.4.5",
+    "ethers": "^6.14.0",
+    "hardhat": "^2.26.0",
     "ripemd160": "^2.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,10 +530,10 @@
     "@nomicfoundation/solidity-analyzer-linux-x64-musl" "0.1.2"
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc" "0.1.2"
 
-"@openzeppelin/contracts@^5.4.0":
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.4.0.tgz#177594bdb2d86c71f5d1052fe40cb4edb95fb20f"
-  integrity sha512-eCYgWnLg6WO+X52I16TZt8uEjbtdkgLC0SUX/xnAksjjrQI4Xfn4iBRoI5j55dmlOhDv1Y7BoR3cU7e3WWhC6A==
+"@openzeppelin/contracts@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.0.0.tgz#ee0e4b4564f101a5c4ee398cd4d73c0bd92b289c"
+  integrity sha512-bv2sdS6LKqVVMLI5+zqnNrNU/CA+6z6CmwFXm/MzmOPBRSO5reEJN7z0Gbzvs0/bv/MZZXNklubpwy3v2+azsw==
 
 "@scure/base@~1.1.0":
   version "1.1.5"


### PR DESCRIPTION
## Summary

- Deploy `EtomicSwap` (SafeERC20 V1) to **Gnosis** (chainId 100, CREATE2 via CreateX, canonical `0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1`) and **GLEEC** (chainId 11169, basic deploy at `0x51d9EfFc20F6965bc8DFD37E797ac52a72fcdb9D`)
- Pin `@openzeppelin/contracts` to exact `5.0.0` and `solidity.evmVersion` to `"paris"` — these were implicit in the earlier Ethereum mainnet deploy but missing from the repo, so today's local compile produced a different CREATE2 address until both were pinned
- Fix `etherscan.apiKey` config: must be an **object** (per-network keys), not a string — `hardhat-verify` silently ignores `customChains` and routes everything through Etherscan V2 when `apiKey` is a string, breaking verification on Blockscout chains (KCC, EWC, GLEEC)
- Set a browser User-Agent on the GLEEC RPC: the upstream `evm-rpc.gleec.com` is Cloudflare-fronted and 503s Hardhat's default JSON-RPC client mid-deploy

## On-chain verifications

- Gnosis: https://gnosisscan.io/address/0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1#code
- GLEEC: https://evm-explorer.gleec.com/address/0x51d9EfFc20F6965bc8DFD37E797ac52a72fcdb9D#code